### PR TITLE
(maint) Change curl to import the text from a file

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -45,7 +45,7 @@ run_langtool() {
     curl --silent \
       --request POST \
       --data "${DATA}" \
-      --data-urlencode "text=$(cat "${FILE}")" \
+      --data-urlencode "text@${FILE}" \
       "${API_ENDPOINT}/v2/check" | \
       FILE="${FILE}" tmpl /langtool.tmpl
   done


### PR DESCRIPTION
## Description Of Changes

This change allows files that contain text that is longer than what is
allowed to be passed in through the commandline to still work.

The drawback of this approach is that the action takes longer to go
through all of the files in the repository.

## Motivation and Context

To be able to run this action on our documentation repositories.

## Testing

1. It was tested manually in one of my personal repositories through GitHub.
2. Not found a way to test this locally.

### Operating Systems Testing

N/A

## Change Types Made
<!-- Tick the boxes for the type of changes that have been made -->

* [x] Bug fix (non-breaking change).
* [x] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

N/A