### PR TITLE
(maint) Add ability for files to check to continue a space

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -39,6 +39,9 @@ set -o noglob
 FILES="$(git ls-files | ghglob ${INPUT_PATTERNS})"
 set +o noglob
 
+# To manage whitespaces in filepath
+IFS=$(echo -en "\n\b")
+
 run_langtool() {
   for FILE in ${FILES}; do
     echo "Checking ${FILE}..." >&2

--- a/testdata/text with spaces.md
+++ b/testdata/text with spaces.md
@@ -1,0 +1,7 @@
+It doesn't works on an unix environment.
+
+It maybe helpful in the future if Austin Energy goes combined cycle.
+
+It still possible for Tom to build a similar chart.
+
+You can do that if need.


### PR DESCRIPTION
## Description Of Changes

This change adds the ability to still run files that include a space in
their filename through language server.

## Motivation and Context

Without this change, any file that contains a space in their name makes
the action fail.

## Testing

1. Tested in my own personal repositories.
2. Not found a way to test this locally.

### Operating Systems Testing

N/A

## Change Types Made

* [x] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

N/A