### PR TITLE
(maint) Add ability to specify a ref to compare against

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,20 @@ jobs:
           github_token: ${{ secrets.github_token }}
           reporter: github-pr-check
           level: info
+  test-pr-change-check:
+    if: github.event_name == 'pull_request'
+    name: runner / languagetool (github-pr-check) (Changed)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: ./
+        with:
+          github_token: ${{ secrets.github_token }}
+          reporter: github-pr-check
+          level: info
+          base_ref: develop
 
   test-pr-review:
     if: github.event_name == 'pull_request'

--- a/action.yml
+++ b/action.yml
@@ -37,6 +37,9 @@ inputs:
   custom_api_endpoint:
     description: 'Custom API endpoint of LanguageTool server. e.g. https://languagetool.org/api'
     default: ''
+  base_ref:
+    description: 'The branch or commit reference that files changed or added should be collected from. Will use the default branch if coming from a pull request if not set.'
+    default: ''
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -36,7 +36,11 @@ fi
 
 # Disable glob to handle glob patterns with ghglob command instead of with shell.
 set -o noglob
-FILES="$(git ls-files | ghglob ${INPUT_PATTERNS})"
+if [ -n "${INPUT_BASE_REF}" ]; then
+  FILES="$(git diff "origin/${INPUT_BASE_REF}" --name-only | ghglob "${INPUT_PATTERNS}")"
+else
+  FILES="$(git ls-files | ghglob "${INPUT_PATTERNS}")"
+fi
 set +o noglob
 
 # To manage whitespaces in filepath


### PR DESCRIPTION
## Description Of Changes

This change allows the GitHub action workflow to specify a specific
reference to be used when finding files to send to the language server.

This allows the the languagetool check to use less time by only compare
any new or changed files, instead of running all of the files in the
repository through the language server.

Additional work is needed for repositories after this change is merged.

## Motivation and Context

To speed up the processing in large repositories, and not check any files that isn't needed to be checked.

## Testing

1. Tested in one of my own forks.
2. Not found a way to test it locally.

### Operating Systems Testing

N/A

## Change Types Made
<!-- Tick the boxes for the type of changes that have been made -->

* [ ] Bug fix (non-breaking change).
* [x] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

N/A